### PR TITLE
Add channel information to mamba installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then, optionally, set up [dotfiles](https://github.com/fastai/dotfiles):
 ```
 source setup-conda.sh
 . ~/.bashrc
-conda install -yq mamba
+conda install -yq mamba -c conda-forge
 ```
 
 To set up email:


### PR DESCRIPTION
- Since now, `setup-conda.sh` uses miniconda. In the default channel mamba is not present:

So we have to install mamba this way

`conda install -yq mamba -c conda-forge`

- Do let me know if I missed anything, and is there anything different now. If yes, I will like to update this article as well:

https://kurianbenoy.com/posts/2022/2022-05-28-fastai-walthrus1.html