### PR TITLE
Add homebrew installation command

### DIFF
--- a/ubuntu-initial.sh
+++ b/ubuntu-initial.sh
@@ -80,6 +80,9 @@ apt-fast -qy install vim-nox python3-powerline rsync ubuntu-drivers-common pytho
 env DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=mail apt-fast full-upgrade -qy -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold'
 sudo apt -qy autoremove
 
+# Install homebrew
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
 mkdir -p ~/.ssh
 chmod 700 ~/.ssh
 cat << 'EOF' >> ~/.ssh/config


### PR DESCRIPTION
Homebrew makes installation and management of packages easier and works on Linux as well as Mac! Adding this will give more flexibility for package installation for servers such as installing the `llama.cpp` package. This PR adds the command to install it using the recommended installation command from: https://brew.sh/

